### PR TITLE
Return coords as numeric instead of chr in fmi_weather_stations()

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -221,7 +221,7 @@ getRasterLayerNames <- function(startDateTime, endDateTime, by, variables,
 fmi_weather_stations <- function() {
   csv.file <- system.file("extdata", "weather_stations.csv", package = "fmi")
   weather.stations <- read.table(csv.file, sep = ";", header = TRUE, 
-                                 as.is = TRUE)
+                                 dec = ",", as.is = TRUE)
   return(weather.stations)
 }  
 


### PR DESCRIPTION
At the moment, `fmi_weather_stations() ` returns the `Lat` and `Lon` coordinates as `character`, because the included file `inst/extdata/weather_stations.csv` uses `,` as the decimal separator. This PR reads them as `numeric`.

Another possibility would of course be to modify the `csv` file and change the decimal separators.